### PR TITLE
Introduce cost-reporter role module

### DIFF
--- a/cost-reporter-role/main.tf
+++ b/cost-reporter-role/main.tf
@@ -3,42 +3,47 @@ resource "aws_iam_policy" "cost_reporter_policy" {
   path        = "/"
   description = "Read-only actions on cost explorer for cost reporting"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = [
-          "ce:Describe*",
-          "ce:Get*",
-          "ce:List*"
-        ]
-        Effect   = "Allow"
-        Resource = "*"
-      },
-    ]
-  })
+  policy = data.aws_iam_policy_document.cost_reporter_policy_document.json
 }
 
-resource "aws_iam_role" "cost_reporter_reporter" {
+data "aws_iam_policy_document" "cost_reporter_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ce:Describe*",
+      "ce:Get*",
+      "ce:List*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cost_reporter_role" {
   name = "cost-reporter"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Sid    = ""
-        Principal = {
-          # a lambda role in telia-no-neo-stage 
-          AWS = "arn:aws:iam::059937321589:role/cost-reporter-lambda-execution-role"
-        }
-      },
-    ]
-  })
+  assume_role_policy = data.aws_iam_policy_document.cost_reporter_assume_role_policy.json
+  tags = {
+    purpose = "Role assumed by cost reporter lambda for retrieving cost information"
+  }
+}
+
+data "aws_iam_policy_document" "cost_reporter_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        # a lambda role in telia-no-neo-stage
+        "arn:aws:iam::059937321589:role/cost-reporter-lambda-execution-role",
+      ]
+    }
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
-  role       = aws_iam_role.cost_reporter_reporter.name
+  role       = aws_iam_role.cost_reporter_role.name
   policy_arn = aws_iam_policy.cost_reporter_policy.arn
 }

--- a/cost-reporter-role/main.tf
+++ b/cost-reporter-role/main.tf
@@ -1,0 +1,44 @@
+resource "aws_iam_policy" "cost_reporter_policy" {
+  name        = "cost-reporter-policy"
+  path        = "/"
+  description = "Read-only actions on cost explorer for cost reporting"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ce:Describe*",
+          "ce:Get*",
+          "ce:List*"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "cost_reporter_reporter" {
+  name = "cost-reporter"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          # a lambda role in telia-no-neo-stage 
+          AWS = "arn:aws:iam::059937321589:role/cost-reporter-lambda-execution-role"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.cost_reporter_reporter.name
+  policy_arn = aws_iam_policy.cost_reporter_policy.arn
+}


### PR DESCRIPTION
This module creates a policy and a role that can be assumed by the
cost-reporter lambda running in a different account to aggregate cost
information.