### PR TITLE
ALB: Disable access logs by default and block all public access to S3 bucket

### DIFF
--- a/alb/alb-variables.tf
+++ b/alb/alb-variables.tf
@@ -74,6 +74,12 @@ variable "logs_s3_bucket_id" {
   type        = string
 }
 
+variable "enabled_access_logs" {
+  description = "Enable ALB access logging to S3 bucket."
+  default     = false
+  type        = bool
+}
+
 variable "acm_certificate_arn" {
   description = "ARN of the SSL certificate"
   type        = string

--- a/alb/alb.tf
+++ b/alb/alb.tf
@@ -57,7 +57,7 @@ module "alb" {
   access_logs = {
     bucket  = var.logs_s3_bucket_id
     prefix  = "alb"
-    enabled = true
+    enabled = var.enabled_access_logs
   }
 
   tags = merge(

--- a/s3-alb-log-bucket/main.tf
+++ b/s3-alb-log-bucket/main.tf
@@ -49,3 +49,12 @@ resource "aws_s3_bucket" "logs" {
 
   tags = local.logs_bucket_tags
 }
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}


### PR DESCRIPTION
Enabling access logs is now possible via variable.