### PR TITLE
Increase retry limit for calling SSM parameter store.

### DIFF
--- a/start-stop-lambda/src/ssm.js
+++ b/start-stop-lambda/src/ssm.js
@@ -1,5 +1,8 @@
 const AWS = require("aws-sdk");
-const ssm = new AWS.SSM({apiVersion: '2014-11-06'});
+const ssm = new AWS.SSM({
+    apiVersion: '2014-11-06',
+    maxRetries: 20
+});
 
 
 exports.readParam = async (key) => {


### PR DESCRIPTION
This change should resolve the problem with Throttling exception which appears randomly during the stop of the environment.
See [here in telia-no-order-dev](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fstart-stop-lambda/log-events/2022$252F10$252F13$252F$255B$2524LATEST$255D9e5fffa147634ce1b5397ed9c9931479).
The default value for the _maxRetries_ variable is undefined.

The value 20 seems like a good enough value to prevent throttling. Tested locally by this code:
```javascript
const AWS = require("aws-sdk");
AWS.config.update({region: 'eu-west-1'});
const ssm = require('./ssm.js');


async function stressTest() {

    for (var i = 0; i < 1000; i++) {
        ssm.paramExists("/StopStartService/SystemIsStopped");
    }


}

stressTest();
stressTest();
```
