### PR TITLE
Nodejs runtime upgrades

### DIFF
--- a/ecs-desired-task-number-lambda/lambda.tf
+++ b/ecs-desired-task-number-lambda/lambda.tf
@@ -68,7 +68,7 @@ resource "aws_lambda_function" "desired_task_lambda" {
   memory_size   = 128
   timeout       = 900
 
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.desired_task_lambda.arn
   source_code_hash = data.archive_file.desired_ecs_task_number_lambda_zip.output_base64sha256
   handler          = "index.handler"

--- a/ecs-desired-task-number-lambda/lambda/src/index.js
+++ b/ecs-desired-task-number-lambda/lambda/src/index.js
@@ -8,7 +8,7 @@ exports.handler = (event, context, callback) => {
   service: event.serviceName,
   cluster: event.clusterName
  };
- console.log("Input parameters: " + JSON.stringify(params)); 
+ console.log("Input parameters: %j", params); 
 
  ecs.updateService(params, function(err, data) {
    if (err) console.log(err, err.stack); // an error occurred

--- a/ecs-monitor-lambda/lambda/template.yml
+++ b/ecs-monitor-lambda/lambda/template.yml
@@ -23,7 +23,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: src/handlers/ecs-deploy-monitor.monitorHandler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           ENV_CLIENT_SECRET_BASE64_PARAM_PATH: "/rmtool/basicauth"

--- a/ecs-monitor-lambda/main.tf
+++ b/ecs-monitor-lambda/main.tf
@@ -106,7 +106,7 @@ resource "aws_lambda_function" "ecs-monitor-lambda" {
   memory_size   = 128
   timeout       = 900
 
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.ecs-monitor-lambda.arn
   source_code_hash = data.archive_file.ecs-monitor-lambda_zip.output_base64sha256
   handler          = "src/handlers/ecs-deploy-monitor.monitorHandler"

--- a/ecs-scale-in-management-lambda/lambda.tf
+++ b/ecs-scale-in-management-lambda/lambda.tf
@@ -67,7 +67,7 @@ resource "aws_lambda_function" "scale_in_lambda" {
   memory_size   = 128
   timeout       = 900
 
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs16.x"
   role             = aws_iam_role.scale_in_lambda.arn
   source_code_hash = data.archive_file.scale-in-lambda-zip.output_base64sha256
   handler          = "app.lambdaHandler"

--- a/ecs-scale-in-management-lambda/lambda/events/event.json
+++ b/ecs-scale-in-management-lambda/lambda/events/event.json
@@ -1,4 +1,3 @@
-//for testing only
 {
-  "body": "{\"policyNames\": \"pm-at1aws-autoscaling-policy,pm-at1aws-autoscaling-policy-cpu\", \"disableScaleIn\": true}"
+  "body": {"policyNames": "pm-at1aws-autoscaling-policy,pm-at1aws-autoscaling-policy-cpu", "disableScaleIn": true}
 }

--- a/ecs-scale-in-management-lambda/lambda/template.yaml
+++ b/ecs-scale-in-management-lambda/lambda/template.yaml
@@ -17,4 +17,4 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: app.lambdaHandler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x


### PR DESCRIPTION
Version 14 is deprecated.
Latest is 18 however, our lambdas use aws-sdk-2 which no longer included there. So upgrading to v16 for the time being. 