### PR TITLE
Increase RDS waiter timeout to 5 minutes

### DIFF
--- a/start-stop-lambda/src/rds.js
+++ b/start-stop-lambda/src/rds.js
@@ -71,5 +71,5 @@ const startDbInstance = async (name) => {
 };
 
 const waitOnDbInstanceAvailable = async (dbIdentifier) => {
-    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 * 5 }, { DBInstanceIdentifier: dbIdentifier });
+    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 * 15 }, { DBInstanceIdentifier: dbIdentifier });
 }

--- a/start-stop-lambda/src/rds.js
+++ b/start-stop-lambda/src/rds.js
@@ -71,5 +71,5 @@ const startDbInstance = async (name) => {
 };
 
 const waitOnDbInstanceAvailable = async (dbIdentifier) => {
-    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 }, { DBInstanceIdentifier: dbIdentifier });
+    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 * 5 }, { DBInstanceIdentifier: dbIdentifier });
 }


### PR DESCRIPTION
Due to a bug in the waiter that doesn't wait fully requested amount