### PR TITLE
Introduce additional start trigger

### DIFF
--- a/start-stop-lambda/main.tf
+++ b/start-stop-lambda/main.tf
@@ -92,6 +92,12 @@ resource "aws_cloudwatch_event_rule" "start_system" {
   schedule_expression = "cron(${var.start_schedule_expression})"
 }
 
+resource "aws_cloudwatch_event_rule" "fail_safe_start_system" {
+  count               = var.fail_safe_start_schedule_expression == "" ? 0 : 1
+  name                = "fail-safe-start-system-lambda-rule"
+  schedule_expression = "cron(${var.fail_safe_start_schedule_expression})"
+}
+
 resource "aws_cloudwatch_event_target" "start_lambda" {
   target_id = aws_lambda_function.start_stop_lambda.function_name
   rule      = aws_cloudwatch_event_rule.start_system.name

--- a/start-stop-lambda/variables.tf
+++ b/start-stop-lambda/variables.tf
@@ -9,6 +9,12 @@ variable "start_schedule_expression" {
   type        = string
 }
 
+variable "fail_safe_start_schedule_expression" {
+  description = "Optional fail-safe start trigger in case initially scheduled start attempt fails or times out."
+  type        = string
+  default     = ""
+}
+
 variable "stop_schedule_expression" {
   description = "Stop system schedule expression, can be in crontab"
   type        = string


### PR DESCRIPTION
A fail-safe trigger schedule that attempts to start the system again.

Useful when the initial start attempt fails or times out due to database start up taking longer than 15 minutes.