### PR TITLE
Add min-max delay in RDS await

### DIFF
--- a/start-stop-lambda/src/rds.js
+++ b/start-stop-lambda/src/rds.js
@@ -71,5 +71,5 @@ const startDbInstance = async (name) => {
 };
 
 const waitOnDbInstanceAvailable = async (dbIdentifier) => {
-    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 * 15 }, { DBInstanceIdentifier: dbIdentifier });
+    await waitUntilDBInstanceAvailable({ client, maxWaitTime: 60 * 15, minDelay: 15, maxDelay: 15 }, { DBInstanceIdentifier: dbIdentifier });
 }


### PR DESCRIPTION
To avoid waiting for 2 minutes before checking when max wait time is close.