### PR TITLE
NOXT 34728

### DIFF
--- a/elasticache/valkey/main.tf
+++ b/elasticache/valkey/main.tf
@@ -1,9 +1,9 @@
 resource "random_string" "password" {
   length  = 20
-  special = true
+  special = false
   upper   = true
   lower   = true
-  override_special = "!#$%^&*()-_=+[]{}|;:,.?<>"
+  numeric = true
 }
 
 resource "aws_ssm_parameter" "secret" {

--- a/elasticache/valkey/main.tf
+++ b/elasticache/valkey/main.tf
@@ -35,7 +35,7 @@ resource "aws_elasticache_replication_group" "valkey" {
 }
 
 resource "aws_security_group" "valkey" {
-  name        = "${var.env}_${var.component_id}_cache_cluster_sg"
+  name        = "${var.env}_${var.component_id}_valkey_cache_cluster_sg"
   description = "${var.env} ${var.component_id} cache Valkey cluster SG"
   vpc_id      = var.vpc_id
 


### PR DESCRIPTION
- **NOXT-34728: Create a unique "valkey" security group to allow both Valkey and Redis to run simultaneously.**
- **NOXT-34728: Remove special characters from auth token generation to ensure compatibility with AWS Valkey.**
